### PR TITLE
Jeffs branch

### DIFF
--- a/Ping/Ping/AppDelegate.m
+++ b/Ping/Ping/AppDelegate.m
@@ -28,7 +28,7 @@
     
     UIMutableUserNotificationAction *noBTAction = [[UIMutableUserNotificationAction alloc] init];
     noBTAction.identifier = @"NO_BLUETOOTH";
-    noBTAction.title = @"Dismiss The Event";
+    noBTAction.title = @"Turn off BlueTooth";
     noBTAction.activationMode = UIUserNotificationActivationModeBackground;
     noBTAction.authenticationRequired = false;
     noBTAction.destructive = true;
@@ -77,7 +77,7 @@
 #pragma mark - Action upon notification
 
 -(void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification completionHandler:(void (^)())completionHandler{
-    int caseNum;
+    int caseNum = 0;
     
     BlueToothManager *btm = [BlueToothManager sharedBluetoothManager];
     
@@ -87,9 +87,11 @@
         caseNum = 1;
     }
     
+    NSLog(@"Action identifier is %@", identifier);
+    
     switch (caseNum) {
         case 0:
-            [btm start];
+            [btm setUpBluetooth];
             NSLog(@"bluetooth is on!");
             break;
         case 1:

--- a/Ping/Ping/BlueToothManager.h
+++ b/Ping/Ping/BlueToothManager.h
@@ -17,7 +17,6 @@
 + (instancetype)sharedBluetoothManager;
 
 - (void)setUpBluetooth;
-- (void)start;
 - (void)stop;
 
 @end

--- a/Ping/Ping/BlueToothManger.m
+++ b/Ping/Ping/BlueToothManger.m
@@ -60,11 +60,6 @@
         self.fetchedTimeStamp = [NSMutableArray array];
         self.cbuuidLists = [NSMutableArray array];
         
-        self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
-        self.peripheralManager = [[CBPeripheralManager alloc] initWithDelegate:self queue:nil];
-        
-        [self setUpBluetooth];
-        
         self.isScanning = FALSE;
     }
     return self;
@@ -114,6 +109,8 @@
 
 -(void)start{ // starts listening (central) & transmitting (peripheral)
     self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+    self.peripheralManager = [[CBPeripheralManager alloc] initWithDelegate:self queue:nil];
+
     [self.peripheralManager startAdvertising:@{ CBAdvertisementDataServiceUUIDsKey : @[[CBUUID UUIDWithString:[CurrentUser getCurrentUser].UUID]]}];
     self.isTimerValid = TRUE;
     

--- a/Ping/Ping/BlueToothTestViewController.m
+++ b/Ping/Ping/BlueToothTestViewController.m
@@ -32,7 +32,7 @@
 }
 
 - (IBAction)startButtonTapped:(id)sender {
-    [self.btm start];
+    [self.btm setUpBluetooth];
 }
 
 - (IBAction)stopButtonTapped:(id)sender {

--- a/Ping/Ping/CurrentUser.m
+++ b/Ping/Ping/CurrentUser.m
@@ -60,20 +60,23 @@
     
     UILocalNotification *notification = [[UILocalNotification alloc] init];
     notification.alertBody = @"Your event is starting soon!";
-    notification.alertAction = @"open"; //slide to notification.alertAction
+    notification.alertAction = @"start the Bluetooth"; //slide to notification.alertAction
     NSDate *halfAnHourBefore = [event.startTime dateByAddingTimeInterval:-secondsPerHalfAnHour];
     notification.fireDate = halfAnHourBefore;
     notification.soundName = UILocalNotificationDefaultSoundName;
     notification.category = @"BT_CATEGORY";
     
-//    UILocalNotification *notification1 = [[UILocalNotification alloc] init];
-//    notification1.alertBody = @"Your Bluetooth is not turned off!";
-//    notification1.fireDate = event.endTime;
-//    notification1.soundName = UILocalNotificationDefaultSoundName;
+    UILocalNotification *endNotification = [[UILocalNotification alloc] init];
+    endNotification.alertBody = @"Your Bluetooth is not turned off!";
+    endNotification.alertAction = @"stop the Bluetooth";
+    endNotification.fireDate = event.endTime;
+    endNotification.soundName = UILocalNotificationDefaultSoundName;
+    endNotification.category = @"BT_CATEGORY";
     
     [[UIApplication sharedApplication] scheduleLocalNotification:notification];
+    [[UIApplication sharedApplication] scheduleLocalNotification:endNotification];
     
-    NSLog(@"!!Saved notification!! %@", [notification description]);
+    NSLog(@"!!Saved notifications!! Start:%@ and End:%@", [notification description], [endNotification description]);
     
     
     //save event

--- a/Ping/Ping/EventListViewController.swift
+++ b/Ping/Ping/EventListViewController.swift
@@ -94,6 +94,25 @@ class EventListViewController: UIViewController, UITableViewDelegate, UITableVie
     
     func tableView(tableView: UITableView, commitEditingStyle editingStyle: UITableViewCellEditingStyle, forRowAtIndexPath indexPath: NSIndexPath) {
         if (editingStyle == UITableViewCellEditingStyle.Delete) {
+            
+//            // Delete the local notificaitons when the event is removed.
+//            // Not going to work until deletion acutally WORKS on realm.
+//
+//            if let notificationArray: Array = UIApplication.sharedApplication().scheduledLocalNotifications{
+//                if let startNotificationToCancel: UILocalNotification = notificationArray[indexPath.row * 2]{
+//                    UIApplication.sharedApplication().cancelLocalNotification(startNotificationToCancel)
+//                }else{
+//                    print("Could not find start notification to cancel")
+//                }
+//                if let endNotificationToCancel: UILocalNotification = notificationArray[indexPath.row * 2 + 1]{
+//                    UIApplication.sharedApplication().cancelLocalNotification(endNotificationToCancel)
+//                }else{
+//                    print("Could not find ending notification to cancel")
+//                }
+//            }else{
+//                print("Could not find array of notifications")
+//            }
+            
             events.removeAtIndex(indexPath.row)
             self.eventListTableView.deleteRowsAtIndexPaths([indexPath], withRowAnimation: UITableViewRowAnimation.Automatic)
         }

--- a/Ping/Ping/MainViewController.m
+++ b/Ping/Ping/MainViewController.m
@@ -113,7 +113,7 @@
 
 - (IBAction)switchChanged:(id)sender {
     if (self.advertisingSwitch.on) {
-        [self.blueToothManager start];
+        [self.blueToothManager setUpBluetooth];
     }
     
     else {


### PR DESCRIPTION
1. Removed Bluetooth START method, now stop method works.
2. EndNotification added it is notified to users at the endtime of the event.
3. Removing local notification added: When user deletes the event on the event tableview, it will delete its' notification as well. The "removing local notification" function currently won't work since tableview deletion is not working properly (not deleting events on realm). I commented it out since we are going to get exceptions when we try to delete the same row for the second time.
